### PR TITLE
タスク名をshowページから変更可能に

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -42,7 +42,7 @@ class TasksController < ApplicationController
 
     if @task.update(task_params)
       flash[:success] = 'タスクを編集しました'
-      redirect_to tasks_path
+      redirect_to task_path(id: @task.id)
     else
       flash.now[:danger] = 'タスク編集に失敗しました'
       render :show

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,8 +1,0 @@
-<%= form_for(@task) do |f| %>
-  <%= f.label :content, 'タスク' %>
-  <%= f.text_field :content %>
-
-  <%= f.submit '投稿' %>
-<% end %>
-
-<%= link_to '一覧に戻る', tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,4 +1,7 @@
-<h3><%= @task.content %></h3>
+<%= form_for(@task) do |f| %>
+  <h4><%= f.text_field :content %></h4>
+  <%= f.submit '更新' %>
+<% end %>
 <p><%= @task.memo %></p>
 <h4><%= (Date.today - @histories.first.action_at).to_i %>日経過</h4>
 


### PR DESCRIPTION
### 変更点
1. showページで今までタスク名を表示していたところを`text_field`にし、タスク名がもとから入っているように変更
   更新ボタン設置でタスク名を変更可能に。

2. edit.html.erbを削除

3. indexページのeditページヘのリンクを削除