### PR TITLE
修正/履歴がない場合、ページが表示できなくなるバグ

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,8 +5,11 @@
       <div class="card-body">
         <h4><%= task.content %></h4>
         <% @history = task.histories.order(action_at: :desc).first %>
-        <%# binding.pry %>
-        <h5><%= (Date.today - @history.action_at).to_i %>日経過</h5> 
+          <% if @history.present? %>
+            <h5><%= (Date.today - @history.action_at).to_i %>日経過</h5> 
+          <% else %>
+            <h5>まだタスクを行っていません</h5>
+          <% end %>
         <div class="task_menu">
           <button type="button" class="btn btn-info btn-sm"><%= link_to '詳細', task %></button>
           <button type="button" class="btn btn-dark btn-sm"><%= link_to '削除', task, method: :delete, data: { confirm: 'タスクを削除しますか?' } %></button>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,6 +1,10 @@
 <h3><%= @task.content %></h3>
 <p><%= @task.memo %></p>
-<h4><%= (Date.today - @histories.first.action_at).to_i %>日経過</h4>
+  <% if @histories.present? %>
+    <h5><%= (Date.today - @histories.first.action_at).to_i %>日経過</h5> 
+  <% else %>
+    <h5>まだタスクを行っていません</h5>
+  <% end %>
 
 <%= form_with(model:[@task, @history]) do |history| %>
   <%= history.hidden_field :task_id, :value => @task.id %>


### PR DESCRIPTION
### バグ内容
- 新規タスク作成時に履歴を登録しない、もしくは既存のタスクから履歴をすべて削除すると、indexページ内の`<h5><%= (Date.today - @history.action_at).to_i %>日経過</h5> `、showページ内の`<h5><%= (Date.today - @histories.first.action_at).to_i %>日経過</h5>`で、`@history.action_at`,`@histories.action_at`がnilとなりエラー落ちする。

### 修正内容
- 両ページ、erb内で`@history``@histories`が`present?`の場合分けで対応
　存在する場合は今まで通り経過日数、ない場合は まだタスクを行っていません と表示するようにした