### PR TITLE
ヴァリデーション設定と不要な記述の削除

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,18 +1,6 @@
 class HistoriesController < ApplicationController
   before_action :authenticate_user!
 
-#   def index
-#     @histories = current_task.histories.all
-#   end
-
-#   def show
-#     @history = History.find(params[:id])
-#   end
-
-#   def new
-#     @history = History.new
-#   end
-
   def create
     @history = current_user.histories.build(history_params)
     if @history.save
@@ -23,20 +11,6 @@ class HistoriesController < ApplicationController
       # render task_path(id: @history.task_id)
     end
   end
-
-#   def edit
-#     @history = History.find(params[:id])
-#   end
-
-#   def update
-#     @history = History.find(params[:id])
-
-#     if @history.update(history_params)
-#       redirect_to tasks_path
-#     else
-#       render :show
-#     end
-#   end
 
   def destroy
     @history = History.find(params[:id])

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -15,8 +15,13 @@ class HistoriesController < ApplicationController
 
   def create
     @history = current_user.histories.build(history_params)
-    @history.save
-    redirect_to task_path(id: @history.task_id)
+    if @history.save
+      flash[:success] = '実行日を追加しました'
+      redirect_to task_path(id: @history.task_id)
+    else
+      flash[:danger] = '実行日追加に失敗しました'
+      # render task_path(id: @history.task_id)
+    end
   end
 
 #   def edit

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -30,7 +30,7 @@ class TasksController < ApplicationController
         redirect_to tasks_path
       else
         flash[:danger] = 'タスク追加に失敗しました'
-        render :new
+        render :index
       end
       # binding.pry
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -13,11 +13,6 @@ class TasksController < ApplicationController
     @history = History.new
   end
 
-  # def new
-  #   @task = Task.new
-  #   @task.histories.build
-  # end
-
   def create
       @task = current_user.tasks.build(task_params)
       @task.save
@@ -34,10 +29,6 @@ class TasksController < ApplicationController
       end
       # binding.pry
   end
-
-  # def edit
-  #   @task = Task.find(params[:id])
-  # end
 
   def update
     @task = Task.find(params[:id])

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,7 +27,6 @@ class TasksController < ApplicationController
         flash[:danger] = 'タスク追加に失敗しました'
         render :index
       end
-      # binding.pry
   end
 
   def update

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,4 +1,5 @@
 class History < ApplicationRecord
   belongs_to :task
   belongs_to :user
+  validates :action_at, presence: { message: "日付を登録してください" }, on: :create
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,4 +3,5 @@ class Task < ApplicationRecord
   has_many :histories, dependent: :destroy
   accepts_nested_attributes_for :histories
   mount_uploader :icon, ImageUploader
+  validates :content, presence: true, length: { maximum: 20 }
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,7 +1,6 @@
 <%= form_with(model: @task, local: true) do |f| %>
   <label class = "control-label" for="">タスク名</label>
   <%= f.text_field :content %>
-
   <div class="input-group date" data-target-input="nearest">
     <%= f.fields_for :histories do |history| %>
       <label class = "control-label" for="">最終実行日</label>
@@ -11,10 +10,9 @@
       </span>
     <% end %>
   </div>
-
   <%= f.submit '作成' %>
 <% end %>
-
+<%#======================================%>
 <div class="task_index">
   <% @tasks.each do |task| %>
     <div class="card">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -14,7 +14,6 @@
 
   <%= f.submit '作成' %>
 <% end %>
-<%#= link_to 'タスク作成', new_task_path, class: "text-info" %>
 
 <div class="task_index">
   <% @tasks.each do |task| %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,18 +1,18 @@
 <p><%= image_tag @task.icon.url %></p>
-
+<%#======================================%>
 <%= form_for(@task) do |f| %>
   <h4><%= f.text_field :content %></h4>
   <p><%= f.file_field :icon, accept: "image/png,image/jpeg,image/gif" %></p>
   <%= f.text_area :memo %>
   <%= f.submit '更新' %>
 <% end %>
-
+<%#======================================%>
 <% if @histories.present? %>
   <h5><%= (Date.today - @histories.first.action_at).to_i %>日経過</h5> 
 <% else %>
   <h5>まだタスクを行っていません</h5>
 <% end %>
-
+<%#======================================%>
 <%= form_with(model:[@task, @history]) do |history| %>
   <%= history.hidden_field :task_id, :value => @task.id %>
   <div class="input-group date" data-target-input="nearest">
@@ -24,7 +24,7 @@
   </div>
   <%= history.submit '作成' %>
 <% end %>
-
+<%#======================================%>
 <ul>
   <% @histories.each do |history| %>
     <li><%= history.action_at %></li>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -7,7 +7,7 @@
   <%= f.submit '更新' %>
 <% end %>
 
-<% if @history.present? %>
+<% if @histories.present? %>
   <h5><%= (Date.today - @histories.first.action_at).to_i %>日経過</h5> 
 <% else %>
   <h5>まだタスクを行っていません</h5>
@@ -17,7 +17,7 @@
   <%= history.hidden_field :task_id, :value => @task.id %>
   <div class="input-group date" data-target-input="nearest">
       <label class = "control-label" for="">実行日追加</label>
-      <%= history.text_field :action_at, id: "action_at", class: 'form-control datetimepicker-input', data: { target: '#action_at'} %>
+      <%= history.text_field :action_at, id: "action_at", class: 'form-control datetimepicker-input', data: { target: '#action_at'}, required: true %>
       <span class = "input-group-append" data-target = "#action_at" data-toggle = "datetimepicker">
           <span class = "input-group-text"><i class = "fa fa-calendar"></i></span>
       </span>


### PR DESCRIPTION
### 変更点
1. histories_controller等でコメントアウトしてた不要な記述を削除
2. history.rbにaction_atのヴァリデーション追加
3. task.rbにcontentのヴァリデーション追加(presenceと20文字制限)
4. showページの日付追加に`required: true`を追加

### メモ
indexで新規タスクを登録したときは実行日を追加しなくてもいいかもしれないが、history欄を空白のまま登録してしまうとnilでDBに登録されててViewでエラーを吐くようになる。DBにもnilを保存するのはあまりしたくない上、ヴァリデーションも例外措置をとって変更しなければならない。現状でも機能的には問題ないので変更するかは要検討。