### PR TITLE
fix/ログイン画面が表示されなかったのを修正

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,5 @@
 <div class="container-login">
   <h1><%= t('.sign_in') %></h1>
-  <%= render 'shared/flash_messages' %>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="form-group">


### PR DESCRIPTION
### 変更点
1. `devise/sessions/new.html.rb`で存在しないファイルをリンクしていたため、ログインページでエラーが出ていたのを、リンク削除で対処