### PR TITLE
data confirm modal のGemを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "font-awesome-rails"
 gem 'jquery-rails'
 gem 'carrierwave', '~> 2.0'
 gem 'mini_magick'
+gem 'data-confirm-modal'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    data-confirm-modal (1.6.3)
+      railties (>= 3.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -279,6 +281,7 @@ DEPENDENCIES
   bootstrap4-datetime-picker-rails
   byebug
   carrierwave (~> 2.0)
+  data-confirm-modal
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require moment/ja.js
 //= require tempusdominus-bootstrap-4.js
 //= require rails-ujs
+//= require data-confirm-modal
 //= require activestorage
 //= require turbolinks
 //= require_tree .

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -36,6 +36,10 @@
   <hr class="devise-link my-5">
   <div class="form-group">
     <%= link_to "トップページ", root_path, class: 'btn btn-info btn-block mb-4' %>
-    <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete, class: 'btn btn-danger btn-block' %>
+    <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: 
+      { confirm: t('.are_you_sure'),
+        cancel: t('.cancel'),
+        commit: t('.delete')},
+        title: t('.cancel_title'),method: :delete, class: 'btn btn-danger btn-block' %>
   </div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -53,7 +53,10 @@
             <%= f.submit 'TODAY', class: 'btn btn-outline-info mb-1' %>
           <% end %>
           <button type="button" class="btn btn-info btn-sm"><%= link_to '詳細', task %></button>
-          <%= link_to task, method: :delete, data: { confirm: 'タスクを削除しますか?' } do %>
+          <%= link_to task, method: :delete, data: 
+            { confirm: 'タスクを削除しますか?',
+              cancel: 'やめる',
+              commit: '削除する'}, title: '削除確認' do %>
             <i class="fa fa-lg fa-remove fa-fw" style="color:firebrick"></i>
           <% end %>
         </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -22,7 +22,12 @@
     <%= f.text_area :memo, class: 'form-control', placeholder: 'memo' %>
     <div class="showbtninfo">
       <%= f.submit '更新', class: 'btn btn-outline-info'%>
-      <button type="button" class="btn btn-outline-danger"><%= link_to 'タスク削除', @task, class: 'text-danger', method: :delete, data: { confirm: 'タスクを削除しますか?' } %></button>
+      <button type="button" class="btn btn-outline-danger">
+        <%= link_to 'タスク削除', @task, class: 'text-danger', method: :delete, data: 
+          { confirm: '記録を削除しますか?',
+            cancel: 'やめる',
+            commit: '削除する'}, title: '削除確認' %>
+      </button>
     </div>
   </div>
 <% end %>
@@ -44,7 +49,10 @@
   <% @histories.each do |history| %>
     <li class="list-group-item">
       <%= history.action_at.strftime("%Y年 %m月 %d日") %>
-        <%= link_to task_history_path(@task, history), method: :delete, data: { confirm: '記録を削除しますか?' } do %>
+        <%= link_to task_history_path(@task, history), method: :delete, data: 
+          { confirm: '記録を削除しますか?',
+            cancel: 'やめる',
+            commit: '削除する'}, title: '削除確認' do %>
           <i class="fa fa-lg fa-calendar-times-o" style="color:firebrick;"></i>
         <% end %>
     </li>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -93,6 +93,9 @@ ja:
       edit:
         are_you_sure: 本当によろしいですか?
         cancel_my_account: アカウント削除
+        cancel_title: アカウントを削除します
+        cancel: やめる
+        delete: 削除する
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
         title: "%{resource}編集"


### PR DESCRIPTION
### 変更点
- data-confirm-modalのGemを追加しindex,show,アカウント編集ページの削除ボタンに適用
　モーダルウィンドウの見た目が良くなった

下記サイトを参考
　gem 'data-confirm-modal'でbootstrap風アラート
　https://qiita.com/kamishun/items/b529a14cab39291b5910