### PR TITLE
rubocopで処理

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ group :development, :test do
   gem 'faker'
   gem 'capybara'
   gem 'selenium-webdriver'
-
 end
 
 group :development do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::Base
-
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,19 +15,19 @@ class TasksController < ApplicationController
   end
 
   def create
-      @task = current_user.tasks.build(task_params)
-      @task.save
-      if @task.histories.each do |history|
-          history.user_id = current_user.id
-          history.task_id = @task.id
-          history.save
-        end
-        flash[:success] = 'タスクを追加しました'
-        redirect_to tasks_path
-      else
-        flash[:danger] = 'タスク追加に失敗しました'
-        render :index
-      end
+    @task = current_user.tasks.build(task_params)
+    @task.save
+    if @task.histories.each do |history|
+         history.user_id = current_user.id
+         history.task_id = @task.id
+         history.save
+       end
+      flash[:success] = 'タスクを追加しました'
+      redirect_to tasks_path
+    else
+      flash[:danger] = 'タスク追加に失敗しました'
+      render :index
+    end
   end
 
   def update
@@ -52,6 +52,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:id, :content, :icon, :memo, histories_attributes: [:id, :user_id, :task_id, :action_at])
+    params.require(:task).permit(:id, :content, :icon, :memo, histories_attributes:
+                                [:id, :user_id, :task_id, :action_at])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,2 @@
 module ApplicationHelper
-
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -16,8 +16,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url(*args)
     # For Rails 3.1+ asset pipeline compatibility:
+    # rubocop:disable all
     # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  
+    # rubocop:enable all
     "/images/fallback/" + [version_name, "default.png"].compact.join('_')
   end
 
@@ -59,6 +60,8 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   def secure_token
     var = :"@#{mounted_as}_secure_token"
+    # rubocop:disable all
     model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
+    # rubocop:enable all
   end
 end


### PR DESCRIPTION
### 変更点
- task_controller.rbのcreateメソッドを`rubocop -a`でインデントを処理した
　※なお、半角スペースで揃ったため見にくい可能性。
- image_uploder.rbの警告は無視するため該当場所を下記で囲い引っかからないように。
```
# rubocop:disable all
[...]
# rubocop:enable all
```
`or` を`||` にしろとの警告だったが、バグを招きそうだったのでそのままにしている。

今回はブランチを区切ってプルリクにしたが、以後push前に各ブランチでrubocopを作動させるようにする。