### PR TITLE
task.user_idを削除し、createアクションを短くした

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -2,7 +2,7 @@ class HistoriesController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    @history = current_user.histories.build(history_params)
+    @history = History.create(history_params)
     if @history.save
       flash[:success] = '実行日を追加しました'
       redirect_back(fallback_location: tasks_path)
@@ -15,7 +15,7 @@ class HistoriesController < ApplicationController
 
   def destroy
     @history = History.find(params[:id])
-    if @history.user_id == current_user.id
+    if @history.task.user_id == current_user.id
       @history.destroy
       flash[:success] = '記録を削除しました'
       redirect_to task_path(@history.task_id)
@@ -27,7 +27,7 @@ class HistoriesController < ApplicationController
 
   def calendar
     @tasks = current_user.tasks.all
-    @histories = current_user.histories.includes(:task)
+    @histories = History.all.includes(:task)
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -24,12 +24,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = current_user.tasks.build(task_params)
-    @task.histories.each do |history|
-      history.user_id = current_user.id
-      history.task_id = @task.id
-      history.save
-    end
+    @task = current_user.tasks.create(task_params)
     if @task.save
       flash[:success] = 'タスクを追加しました'
       redirect_to tasks_path
@@ -80,7 +75,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:content, :icon, :memo, histories_attributes:
-                                [:task_id, :action_at])
+    params.require(:task).permit(:content, :icon, :memo, histories_attributes: [:id, :action_at])
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,6 +1,5 @@
 class History < ApplicationRecord
   belongs_to :task
-  belongs_to :user
   validates :action_at, presence: { message: "日付を登録してください" }, uniqueness: { scope: :task_id, massage: "同じ日付は登録できません" }
   validate :action_at_be_in_the_future
 

--- a/db/migrate/20201118072301_remove_user_id_from_histories.rb
+++ b/db/migrate/20201118072301_remove_user_id_from_histories.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromHistories < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :histories, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_26_055500) do
+ActiveRecord::Schema.define(version: 2020_11_18_072301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "histories", force: :cascade do |t|
-    t.integer "user_id"
     t.integer "task_id"
     t.date "action_at"
     t.datetime "created_at", null: false

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :history do
     action_at {Faker::Date.backward}
     association :task, factory: :task
-    user { task.user }
   end
 end

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe History, type: :model do
         expect(association.macro).to eq :belongs_to
       end
     end
-
-    context 'userとの関係' do
-      let(:target) { :user }
-
-      it 'N:1となっている' do
-        expect(association.macro).to eq :belongs_to
-      end
-    end
   end
 
   describe 'バリデーションのテスト' do

--- a/spec/requests/histories_request_spec.rb
+++ b/spec/requests/histories_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Histories", type: :request do
   let(:user) { create(:user) }
   let(:task) { create(:task, user_id: user.id) }
-  let(:history) { create(:history, user_id: user.id, task_id: task.id) }
+  let(:history) { create(:history, task_id: task.id) }
 
   describe "GET histories#calendar" do
     before do

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Tasks", type: :request do
   let(:user) { create(:user) }
   let(:task) { create(:task, user_id: user.id) }
-  let(:history) { create(:history, user_id: user.id, task_id: task.id) }
+  let(:history) { create(:history, task_id: task.id) }
 
   describe "GET tasks#index" do
     before do


### PR DESCRIPTION
### 変更点
1. Taskからuser_idカラムを削除
　(taskから辿れば不要なため)
2. task_controllerのcreateアクションを短くできた
3. それに伴いRspecの記述も変更
4. histories_controllerのcreateアクションとcallendarページも表示できなくなっていたので変更