### PR TITLE
datetimepicker不要ファイル削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ http://54.168.27.112/<br>
 
 ##### その他使用技術
 - Action Mailer
-- bootstrap4-datetime-picker-rails
+- flatpickr(カレンダー機能)
 - carrierwave
 - data-confirm-modal
 - devise

--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -1,7 +1,0 @@
-$(document).on('turbolinks:load', function() {
-  $('#action_at').datetimepicker({
-      format: 'YYYY-MM-DD',
-      pickTime : false,
-  });
-});
-


### PR DESCRIPTION
### 変更点
1. datepickr.jsが不要になり、本番環境でエラーがでていたので削除

2. READMEのbootstrap-datetimepickerの記述もflatpickrに変更