### PR TITLE
指摘点修正

### DIFF
--- a/app/assets/javascripts/count.js
+++ b/app/assets/javascripts/count.js
@@ -1,0 +1,3 @@
+function countLength( text, field ) {
+  document.getElementById(field).innerHTML = text.length + "/20文字";
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -134,6 +134,7 @@ footer {
 
 .task-rename {
   margin-left: 30px;
+  margin-right: auto;
   color: #808080;
   font-size: 12px;
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -31,6 +31,7 @@
       <% end %>
 
       <%= render 'devise/shared/links' %>
+      <%= link_to "ゲストログイン", users_guest_sign_in_path , method: :post, class: "btn btn-outline-secondary btn-block" %>
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -29,6 +29,7 @@
       <% end %>
 
       <%= render 'devise/shared/links' %>
+      <%= link_to "ゲストログイン", users_guest_sign_in_path , method: :post, class: "btn btn-outline-secondary btn-block" %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,26 +12,26 @@
         <ul class="navbar-nav">
           <% if user_signed_in? %>
             <li class="nav-item">
-              <i class="fa fa-list-alt fa-fw fa-lg mr-1"></i><%= link_to "ALL TASKS", tasks_path %>
+              <i class="fa fa-list-alt fa-fw fa-lg mr-1"></i><%= link_to "タスク一覧", tasks_path %>
             </li>
             <li class="nav-item">
-              <i class="fa fa-calendar fa-fw fa-lg mr-1"></i><%= link_to 'CALENDAR', calendar_path %>
+              <i class="fa fa-calendar fa-fw fa-lg mr-1"></i><%= link_to 'カレンダー', calendar_path %>
             </li>
               <li class="nav-item">
-              <i class="fa fa-user fa-fw fa-lg"></i> <%= link_to 'ACCOUNT', edit_user_registration_path %>
+              <i class="fa fa-user fa-fw fa-lg"></i> <%= link_to 'アカウント', edit_user_registration_path %>
             </li>
             <li class="nav-item">
-              <i class="fa fa-sign-out fa-fw fa-lg mr-1"></i><%= link_to "SIGN OUT", destroy_user_session_path, method: :delete %>
+              <i class="fa fa-sign-out fa-fw fa-lg mr-1"></i><%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
             </li>
           <% else %>
             <li class="nav-item">
-              <i class="fa fa-sign-in fa-fw fa-lg mr-1"></i><%= link_to "SIGN IN", new_user_session_path %>
+              <i class="fa fa-sign-in fa-fw fa-lg mr-1"></i><%= link_to "ログイン", new_user_session_path %>
             </li>
             <li class="nav-item">
-              <i class="fa fa-user-plus fa-fw fa-lg mr-1"></i><%= link_to "SIGN UP", new_user_registration_path %>
+              <i class="fa fa-user-plus fa-fw fa-lg mr-1"></i><%= link_to "新規登録", new_user_registration_path %>
             </li>
             <li>
-              <i class="fa fa-hand-o-right fa-fw fa-lg mr-1"></i><%= link_to "GUEST LOGIN", users_guest_sign_in_path , method: :post %>
+              <i class="fa fa-hand-o-right fa-fw fa-lg mr-1"></i><%= link_to "ゲストログイン", users_guest_sign_in_path , method: :post %>
             </li>
           <% end %>
         </ul>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -23,17 +23,19 @@
   </div>
 </div>
 <div class="container">
-  <div class="row userlink">
-    <div class="col-lg-12">
+  <div class="row userlink mt-4">
+    <div class="col-lg-6">
       <h3 class="text-center mt-5 mb-3">"あれ、いつやったっけ？"</h3>
       <h3 class="text-center m-3">"何日経ったかな？"</h3>
       <h3 class="text-center mt-4 mb-5">あなたの代わりに覚えます</h3>
-      <h3 class="text-center m-5"><strong>無料で会員登録</strong></h3>
-      <div class="mx-auto mt-4" style="width: 300px; display: flex;">
+    </div>
+    <div class="col-lg-6">
+      <h3 class="text-center mb-5"><strong>無料で会員登録</strong></h3>
+      <div class="mx-auto mt-2" style="width: 300px; display: flex;">
         <p class="mx-auto"><%= link_to "新規登録", new_user_registration_path, class: "btn btn-info btn-lg" %></p>
         <p class="mx-auto"><%= link_to "ログイン", new_user_session_path, class: "btn btn-outline-info btn-lg" %></p>
       </div>
-      <div class="mx-auto mt-4" style="width: 300px;">
+      <div class="mx-auto mt-4 px-3" style="width: 300px;">
         <p class="text-center">
           <%= link_to "ゲストログイン", users_guest_sign_in_path , method: :post, class: "btn btn-outline-secondary btn-block" %>
         </p>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -46,19 +46,19 @@
     <div class="card" style="width: 18rem;">
       <img class="card-img-top" src="/images/index.jpg">
       <div class="card-body">
-        <p class="card-text">タスクと何日経ったかを一覧で　かんたんに確認できます</p>
+        <p class="card-text"><strong>タスクと何日経ったかを一覧で　かんたんに確認できます</strong></p>
       </div>
     </div>
     <div class="card" style="width: 18rem;">
       <img class="card-img-top" src="/images/today.png">
       <div class="card-body">
-        <p class="card-text">TODAYボタンを使って1クリックで経過日をリセットできます</p>
+        <p class="card-text"><strong>TODAYボタンを使って1クリックで経過日をリセットできます</strong></p>
       </div>
     </div>
     <div class="card" style="width: 18rem;">
       <img class="card-img-top" src="/images/calendar.jpg">
       <div class="card-body">
-        <p class="card-text">カレンダーページで今月の履歴をすべて確認できます</p>
+        <p class="card-text"><strong>カレンダーページで今月の履歴をすべて確認できます</strong></p>
       </div>
     </div>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,13 +1,13 @@
 <div class="createtask">
   <button type="button" class="btn btn-outline-dark btn-block hidebtn" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
-    ADD NEW TASK
+    タスク追加
   </button>
   <div class="collapse" id="collapseExample">
     <div class="card" style="margin-top: -1rem;">
       <div class="card-body show-info" style="display: block;">
         <%= form_with(model: @task, local: true) do |f| %>
           <div class="form-group row">
-            <label class="col-sm-2 col-form-label text-muted" for="">TASK NAME</label>
+            <label class="col-sm-2 col-form-label text-muted" for="">タスク追加</label>
             <div class="col-sm-9">
               <%= f.text_field :content, class:'form-control' %>
             </div>
@@ -15,14 +15,14 @@
 
           <div class="form-group row">
             <%= f.fields_for :histories do |history| %>
-              <label class="col-sm-2 col-form-label text-muted" for="">LAST DATE</label>
+              <label class="col-sm-2 col-form-label text-muted" for="">最終実行日</label>
               <div class="col-sm-9">
                 <%= history.text_field :action_at, id: "flatpickr", class: 'form-control bg-white', type: "text", readonly:""%>
               </div>
             <% end %>
           ​</div>
           <div class="text-right">
-            <%= f.submit 'CREATE', class: 'btn btn-outline-dark' %>
+            <%= f.submit 'タスク追加', class: 'btn btn-outline-dark' %>
           </div>
         <% end %>
       </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -9,7 +9,8 @@
           <div class="form-group row">
             <label class="col-sm-2 col-form-label text-muted" for="">タスク追加</label>
             <div class="col-sm-9">
-              <%= f.text_field :content, class:'form-control' %>
+              <%= f.text_field :content, class:'form-control', onKeyUp:"countLength(value, 'textlength');" %>
+              <P class="pull-right" id="textlength">0/20文字</P>
             </div>
           </div>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,6 @@
 <div class="createtask">
   <button type="button" class="btn btn-outline-dark btn-block hidebtn" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
-    タスク追加
+    新規タスク
   </button>
   <div class="collapse" id="collapseExample">
     <div class="card" style="margin-top: -1rem;">
@@ -22,7 +22,7 @@
             <% end %>
           ​</div>
           <div class="text-right">
-            <%= f.submit 'タスク追加', class: 'btn btn-outline-dark' %>
+            <%= f.submit '新規作成', class: 'btn btn-outline-dark' %>
           </div>
         <% end %>
       </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -12,8 +12,8 @@
               </div>
             </div>
             <div class="taskname-date col-lg-8 col-md-7">
-              <h4><i class="fa fa-edit fa-fw"></i><%= f.text_field :content, class: 'border-bottom', style: 'border: none; color: #555555;" ' %></h4>
-              <p class="task-rename">タスクの名前を変更できます</p>
+              <h4><i class="fa fa-edit fa-fw"></i><%= f.text_field :content, class: 'border-bottom', onKeyUp:"countLength(value, 'textlength');", style: 'border: none; color: #555555;" ' %></h4>
+              <p class="task-rename">タスクの名前を変更できます<span class="pull-right" id="textlength"> 0/20文字</span></p>
               <div class="elapsed-date">
                 <h4><i class="fa fa-calendar-minus-o fa-fw"></i>
                   <% if @histories.present? %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -8,7 +8,7 @@
               <p><%= image_tag @task.icon.url %></p>
               <div class="custom-file">
                 <%= f.file_field :icon, class: 'custom-file-input', id: 'customFile', accept: "image/png,image/jpeg,image/gif" %>
-                <label class="custom-file-label" for="customFile" data-browse="FILE">add icon ...</label>
+                <label class="custom-file-label" for="customFile" data-browse="FILE">アイコン追加</label>
               </div>
             </div>
             <div class="taskname-date col-lg-8 col-md-7">
@@ -28,9 +28,9 @@
         </div>
         <%= f.text_area :memo, class: 'form-control', placeholder: 'memo' %>
         <div class="showbtninfo">
-          <%= f.submit 'UPDATE', class: 'btn btn-outline-dark'%>
+          <%= f.submit 'タスク更新', class: 'btn btn-outline-dark'%>
           <button type="button" class="btn btn-outline-danger">
-            <%= link_to 'DELETE TASK', @task, class: 'text-danger', method: :delete, data: 
+            <%= link_to 'タスク削除', @task, class: 'text-danger', method: :delete, data: 
               { confirm: 'タスクを削除しますか?',
                 cancel: 'やめる',
                 commit: '削除する'}, title: '削除確認' %>
@@ -42,8 +42,8 @@
     <%= form_with(model:[@task, @history], local: true) do |history| %>
       <%= history.hidden_field :task_id, :value => @task.id %>
       <div class="addhistories">
-        <%= history.text_field :action_at, id: "flatpickr", class: 'form-control bg-white', type: "text", placeholder: 'ADD DATE', readonly:""%>
-        <%= history.submit 'ADD', class: 'btn btn-outline-dark addhistorybtn' %>
+        <%= history.text_field :action_at, id: "flatpickr", class: 'form-control bg-white', type: "text", placeholder: '実行日追加', readonly:""%>
+        <%= history.submit '追加', class: 'btn btn-outline-dark addhistorybtn' %>
       </div>
     <% end %>
     <%#======================================%>
@@ -62,7 +62,6 @@
     </ul>
 
     <div class="undermenu">
-      
       <button type="button" class="btn btn-dark btn-sm"><%= link_to 'PAGE BACK', tasks_path %></button>
     </div>
   </div>


### PR DESCRIPTION
### 変更点
1. 全体的に日本語に変更
　ターゲットが日本なら英語UIは回避すべきとのことだったので変更した
　日本語だとダサいと思ったところは英語のままにしています。

2. TOPページのログイン、新規登録、ゲストログインボタンがページを開いてすぐ見えないので位置変更
　ユーザーが離脱するタイミングをへらす

3. TOP下の画像つき説明のフォントを太字に変更
　説明フォントが画像のフォントと同じで、説明ということがわからなかったので太字にしました

4. indexとshowページのタスク名フォームに文字数カウンター追加
　20文字制限ということがわかるように設置
　count.jsファイル追加